### PR TITLE
Fix memory leaks found by valgrind — Warning: "%ms" requires POSIX-compliant libc

### DIFF
--- a/test.c
+++ b/test.c
@@ -6,6 +6,7 @@
 #define STRING_ASSERT(expect, str) \
 	do{  \
 		char* s = str; \
+		assert( s ); \
 		assert( strcmp(expect, s) == 0); \
 		free(s); \
 	}while(0)

--- a/test.c
+++ b/test.c
@@ -3,6 +3,14 @@
 #include <assert.h>
 #include <string.h>
 
+#define STRING_ASSERT(expect, str) \
+	do{  \
+		char* s = str; \
+		assert( strcmp(expect, s) == 0); \
+		free(s); \
+	}while(0)
+
+
 int
 main (void) {
   //url_inspect("https://google.com/search?q=github");
@@ -47,25 +55,26 @@ main (void) {
   assert(url_is_protocol("ftp"));
   assert(url_is_protocol("javascript"));
 
-  assert(0 == strcmp("http",                       url_get_protocol(url)));
-  assert(0 == strcmp("user:pass",                  url_get_auth(url)));
-  assert(0 == strcmp("subdomain.host.com:8080",    url_get_hostname(url)));
-  assert(0 == strcmp("subdomain.host.com",         url_get_host(url)));
-  assert(0 == strcmp("/p/a/t/h",                   url_get_pathname(url)));
-  assert(0 == strcmp("/p/a/t/h?query=string#hash", url_get_path(url)));
-  assert(0 == strcmp("?query=string",              url_get_search(url)));
-  assert(0 == strcmp("query=string",               url_get_query(url)));
-  assert(0 == strcmp("#hash",                      url_get_hash(url)));
-  assert(0 == strcmp("8080",                       url_get_port(url)));
+  STRING_ASSERT("http",                       url_get_protocol(url));
+  STRING_ASSERT("user:pass",                  url_get_auth    (url));
+  STRING_ASSERT("subdomain.host.com:8080",    url_get_hostname(url));
+  STRING_ASSERT("subdomain.host.com",         url_get_host    (url));
+  STRING_ASSERT("/p/a/t/h",                   url_get_pathname(url));
+  STRING_ASSERT("/p/a/t/h?query=string#hash", url_get_path    (url));
+  STRING_ASSERT("?query=string",              url_get_search  (url));
+  STRING_ASSERT("query=string",               url_get_query   (url));
+  STRING_ASSERT("#hash",                      url_get_hash    (url));
+  STRING_ASSERT("8080",                       url_get_port    (url));
 
-  assert(0 == strcmp("git",               url_get_protocol(gh_url)));
-  assert(0 == strcmp("github.com",        url_get_host(gh_url)));
-  assert(0 == strcmp("github.com",        url_get_hostname(gh_url)));
-  assert(0 == strcmp("git",               url_get_auth(gh_url)));
-  assert(0 == strcmp("jwerle/url.h.git",  url_get_pathname(gh_url)));
-  assert(0 == strcmp("jwerle/url.h.git",  url_get_path(gh_url)));
+  STRING_ASSERT("git",               url_get_protocol(gh_url));
+  STRING_ASSERT("github.com",        url_get_host    (gh_url));
+  STRING_ASSERT("github.com",        url_get_hostname(gh_url));
+  STRING_ASSERT("git",               url_get_auth    (gh_url));
+  STRING_ASSERT("jwerle/url.h.git",  url_get_pathname(gh_url));
+  STRING_ASSERT("jwerle/url.h.git",  url_get_path    (gh_url));
 
   url_free(parsed);
+  url_free(gh_parsed);
 
   return 0;
 }

--- a/url.c
+++ b/url.c
@@ -126,7 +126,7 @@ url_parse (char *url) {
 
   data->auth = auth;
 
-  char *hostnamec = (is_ssh)
+  char *hostname = (is_ssh)
     ? get_part(tmp_url, "%[^:]", protocol_len + auth_len)
     : get_part(tmp_url, "%[^/]", protocol_len + auth_len);
 
@@ -195,7 +195,7 @@ url_parse (char *url) {
   strcpy(search, "");
   sscanf(tmp_path, "%[^#]", search);
   data->search = search;
-  const search_len = strlen(search);
+  const size_t search_len = strlen(search);
   free(tmp_path);
 
   char *query = (char *) malloc(sizeof(char));

--- a/url.c
+++ b/url.c
@@ -275,8 +275,10 @@ url_get_hostname (char *url) {
   char *auth = url_get_auth(url);
 
   if (!protocol) return NULL;
-  if (auth) l += strlen(auth) + 1; // add one @ symbol
-  if (auth) free(auth);
+  if (auth) {
+    l += strlen(auth) + 1; // add one @ symbol
+    free(auth);
+  }
 
   l += strlen(protocol);
 
@@ -344,7 +346,7 @@ url_get_path (char *url) {
   char *path = (char *) malloc(strlen(tmp_path));
   sprintf(path, fmt, tmp_path);
 
-  if (auth) free(auth);
+  free(auth);
   free(protocol);
   free(hostname);
   free(tmp_path);
@@ -404,7 +406,7 @@ url_get_hash (char *url) {
   free(tmp_path);
   free(pathname);
   free(path);
-  if (search) free(search);
+  free(search);
 
   return hash;
 }
@@ -449,15 +451,15 @@ url_data_inspect (url_data_t *data) {
 void
 url_free (url_data_t *data) {
   if (!data) return;
-  if (data->auth) free(data->auth);
-  if (data->protocol) free(data->protocol);
-  if (data->hostname) free(data->hostname);
-  if (data->host) free(data->host);
-  if (data->pathname) free(data->pathname);
-  if (data->path) free(data->path);
-  if (data->hash) free(data->hash);
-  if (data->port) free(data->port);
-  if (data->search) free(data->search);
-  if (data->query) free(data->query);
+  free(data->auth);
+  free(data->protocol);
+  free(data->hostname);
+  free(data->host);
+  free(data->pathname);
+  free(data->path);
+  free(data->hash);
+  free(data->port);
+  free(data->search);
+  free(data->query);
   free(data);
 }

--- a/url.c
+++ b/url.c
@@ -43,8 +43,8 @@ strdup (const char *str) {
 
 
 static char *
-strff (char *ptr, int n) {
-  for (int i = 0; i < n; ++i) {
+strff (char *ptr, size_t n) {
+  for (size_t i = 0; i < n; ++i) {
     (void) *ptr++;
   }
 
@@ -52,8 +52,8 @@ strff (char *ptr, int n) {
 }
 
 static char *
-strrwd (char *ptr, int n) {
-  for (int i = 0; i < n; ++i) {
+strrwd (char *ptr, size_t n) {
+  for (size_t i = 0; i < n; ++i) {
     (void) *ptr--;
   }
 
@@ -111,7 +111,7 @@ url_parse (char *url) {
     return NULL;
   }
   // length of protocol plus ://
-  int protocol_len = (int) strlen(protocol) + 3;
+  const size_t protocol_len = strlen(protocol) + 3;
   data->protocol = protocol;
 
   is_ssh = url_is_ssh(protocol);
@@ -126,9 +126,7 @@ url_parse (char *url) {
 
   data->auth = auth;
 
-  char *hostname;
-
-  hostname = (is_ssh)
+  char *hostnamec = (is_ssh)
     ? get_part(tmp_url, "%[^:]", protocol_len + auth_len)
     : get_part(tmp_url, "%[^/]", protocol_len + auth_len);
 
@@ -137,11 +135,11 @@ url_parse (char *url) {
     url_free(data);
     return NULL;
   }
-  int hostname_len = (int) strlen(hostname);
+  const size_t hostname_len = strlen(hostname);
   char *tmp_hostname = strdup(hostname);
   data->hostname = hostname;
 
-  char *host = (char *) malloc((strlen(tmp_hostname)+1) * sizeof(char));
+  char *host = (char *) malloc((strlen(tmp_hostname)+1));
   sscanf(tmp_hostname, "%[^:]", host);
   free(tmp_hostname);
   if (!host) {
@@ -151,16 +149,14 @@ url_parse (char *url) {
   }
   data->host = host;
 
-  int host_len = (int)strlen(host);
+  const size_t host_len = strlen(host);
   if (hostname_len > host_len) {
     data->port = strff(hostname, host_len + 1); // +1 for ':' char;
   } else {
     data->port = NULL;
   }
 
-  char *tmp_path;
-
-  tmp_path = (is_ssh)
+  char *tmp_path = (is_ssh)
     ? get_part(tmp_url, ":%s", protocol_len + auth_len + hostname_len)
     : get_part(tmp_url, "/%s", protocol_len + auth_len + hostname_len);
 
@@ -184,7 +180,7 @@ url_parse (char *url) {
   strcat(pathname, "");
   tmp_path = strdup(path);
   sscanf(tmp_path, "%[^? | ^#]", pathname);
-  int pathname_len = (int)strlen(pathname);
+  const size_t pathname_len = strlen(pathname);
   data->pathname = pathname;
 
   char *search = (char *) malloc(sizeof(search));
@@ -199,7 +195,7 @@ url_parse (char *url) {
   strcpy(search, "");
   sscanf(tmp_path, "%[^#]", search);
   data->search = search;
-  int search_len = (int)strlen(search);
+  const search_len = strlen(search);
   free(tmp_path);
 
   char *query = (char *) malloc(sizeof(char));
@@ -229,9 +225,9 @@ url_parse (char *url) {
 
 bool
 url_is_protocol (char *str) {
-  int count = sizeof(URL_SCHEMES) / sizeof(URL_SCHEMES[0]);
+  const unsigned count = sizeof(URL_SCHEMES) / sizeof(URL_SCHEMES[0]);
 
-  for (int i = 0; i < count; ++i) {
+  for (unsigned i = 0; i < count; ++i) {
     if (0 == strcmp(URL_SCHEMES[i], str)) {
       return true;
     }
@@ -267,13 +263,13 @@ char *
 url_get_auth (char *url) {
   char *protocol = url_get_protocol(url);
   if (!protocol) return NULL;
-  int l = (int) strlen(protocol) + 3;
+  const size_t l = strlen(protocol) + 3;
   return get_part(url, "%[^@]", l);
 }
 
 char *
 url_get_hostname (char *url) {
-  int l = 3;
+  size_t l = 3;
   char *protocol = url_get_protocol(url);
   char *tmp_protocol = strdup(protocol);
   char *auth = url_get_auth(url);
@@ -282,7 +278,7 @@ url_get_hostname (char *url) {
   if (auth) l += strlen(auth) + 1; // add one @ symbol
   if (auth) free(auth);
 
-  l += (int) strlen(protocol);
+  l += strlen(protocol);
 
   free(protocol);
 
@@ -324,7 +320,7 @@ url_get_pathname (char *url) {
 
 char *
 url_get_path (char *url) {
-  int l = 3;
+  size_t l = 3;
   char *tmp_path;
   char *protocol = url_get_protocol(url);
   char *auth = url_get_auth(url);
@@ -336,9 +332,9 @@ url_get_path (char *url) {
 
   bool is_ssh = url_is_ssh(protocol);
 
-  l += (int) strlen(protocol) + (int) strlen(hostname);
+  l += strlen(protocol) + strlen(hostname);
 
-  if (auth) l+= (int) strlen(auth) +1; // @ symbol
+  if (auth) l+= strlen(auth) +1; // @ symbol
 
   tmp_path = (is_ssh)
     ? get_part(url, ":%s", l)
@@ -354,7 +350,6 @@ url_get_path (char *url) {
   free(tmp_path);
 
   return path;
-
 }
 
 char *
@@ -399,8 +394,8 @@ url_get_hash (char *url) {
   if (!pathname) return NULL;
   char *search = url_get_search(url);
 
-  int pathname_len = (int) strlen(pathname);
-  int search_len = (int) strlen(search);
+  const size_t pathname_len = strlen(pathname);
+  const size_t search_len   = strlen(search);
   char *tmp_path = strff(path, pathname_len + search_len);
 
   strcat(hash, "");

--- a/url.c
+++ b/url.c
@@ -164,7 +164,7 @@ url_parse (char *url) {
     ? get_part(tmp_url, ":%s", protocol_len + auth_len + hostname_len)
     : get_part(tmp_url, "/%s", protocol_len + auth_len + hostname_len);
 
-  char *path = (char *) malloc((strlen(tmp_path) + 2) * sizeof(char));
+  char *path = (char *) malloc((strlen(tmp_path) + 2));
   if (!path) {
     free(tmp_url);
     url_free(data);
@@ -174,7 +174,7 @@ url_parse (char *url) {
   sprintf(path, fmt, tmp_path);
   data->path = path;
 
-  char *pathname = (char *) malloc((strlen(tmp_path) + 2) * sizeof(char));
+  char *pathname = (char *) malloc((strlen(tmp_path) + 2));
   free(tmp_path);
   if (!pathname) {
     free(tmp_url);
@@ -255,7 +255,7 @@ url_is_ssh (char *str) {
 
 char *
 url_get_protocol (char *url) {
-  char *protocol = (char *) malloc(URL_PROTOCOL_MAX_LENGTH * sizeof(char));
+  char *protocol = (char *) malloc(URL_PROTOCOL_MAX_LENGTH);
   if (!protocol) return NULL;
   sscanf(url, "%[^://]", protocol);
   if (url_is_protocol(protocol)) return protocol;
@@ -345,7 +345,7 @@ url_get_path (char *url) {
     : get_part(url, "/%s", l);
 
   const char *fmt = (is_ssh)? "%s" : "/%s";
-  char *path = (char *) malloc(strlen(tmp_path) * sizeof(char));
+  char *path = (char *) malloc(strlen(tmp_path));
   sprintf(path, fmt, tmp_path);
 
   if (auth) free(auth);

--- a/url.c
+++ b/url.c
@@ -426,20 +426,27 @@ url_inspect (char *url) {
 }
 
 
+#define PRINT_MEMBER(member)  do{ \
+	if(data->member) \
+		printf("    ." #member ": \"%s\"\n", data->member);  \
+	else   \
+		printf("    ." #member ": (NULL)\n");  \
+	}while(0)
+
 void
 url_data_inspect (url_data_t *data) {
   printf("#url =>\n");
-  printf("    .href: \"%s\"\n",     data->href);
-  printf("    .protocol: \"%s\"\n", data->protocol);
-  printf("    .host: \"%s\"\n",     data->host);
-  printf("    .auth: \"%s\"\n",     data->auth);
-  printf("    .hostname: \"%s\"\n", data->hostname);
-  printf("    .pathname: \"%s\"\n", data->pathname);
-  printf("    .search: \"%s\"\n",   data->search);
-  printf("    .path: \"%s\"\n",     data->path);
-  printf("    .hash: \"%s\"\n",     data->hash);
-  printf("    .query: \"%s\"\n",    data->query);
-  printf("    .port: \"%s\"\n",     data->port);
+  PRINT_MEMBER(href);
+  PRINT_MEMBER(protocol);
+  PRINT_MEMBER(host);
+  PRINT_MEMBER(auth);
+  PRINT_MEMBER(hostname);
+  PRINT_MEMBER(pathname);
+  PRINT_MEMBER(search);
+  PRINT_MEMBER(path);
+  PRINT_MEMBER(hash);
+  PRINT_MEMBER(query);
+  PRINT_MEMBER(port);
 }
 
 void


### PR DESCRIPTION
I ran the test program on my Linux machine with valgrind and found a lot of memory leaks. They are also mentioned in issue #6 

I fixed first the memory leaks in test.c itself, and in url.c afterwards.

Nota bene: I use now the %ms format specifier in sscanf() that is part of POSIX but **not part of ISO C**, so it might not work on MS Visual Studio, I guess. Perhaps these parts in the code should be changed if this is an issue.

Additionally, valgrind also found some other memory access violations, that are not (yet) fixed in my branch.